### PR TITLE
Fix dead cancellation guard in compression preview debounce

### DIFF
--- a/src/pages/Compression/components/ReviewScreen.tsx
+++ b/src/pages/Compression/components/ReviewScreen.tsx
@@ -296,9 +296,9 @@ export const ReviewScreen = ({
     if (targetSize <= 0) return
     setPreviewStale(true)
     const hashes = Array.from(selected)
+    let cancelled = false
     // Debounced: ticking a dozen boxes should measure once, not a dozen times.
     const timer = setTimeout(() => {
-      let cancelled = false
       api
         .previewCandidate(candidate.id, {
           approved: hashes,
@@ -313,11 +313,11 @@ export const ReviewScreen = ({
         .catch(() => {
           if (!cancelled) setPreviewStale(false)
         })
-      return () => {
-        cancelled = true
-      }
     }, 400)
-    return () => clearTimeout(timer)
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selected, targetSize, candidate.id])
 


### PR DESCRIPTION
## What changed

In `ReviewScreen.tsx`, the debounced candidate-preview effect declared its `cancelled` flag inside the `setTimeout` callback and returned a cleanup function from that same callback. `setTimeout` ignores whatever its callback returns, so that cleanup was never invoked and `cancelled` was permanently `false` — the guard was dead code.

## Why

Without a working cancellation guard, if the preview request from an older selection resolves after a newer one has already been kicked off (e.g. two `previewCandidate` calls racing after quick checkbox toggles), the stale response can overwrite the fresher preview shown to the operator, with no indication anything is wrong.

The fix hoists `cancelled` to the effect body and moves the flip into the effect's own cleanup function (alongside `clearTimeout`), matching the pattern already used for the same purpose in `ProfileSizeFields.tsx`.

## How verified

- `npm run build` (tsc + vite build) — passes
- `npm test` (vitest, all 3 test files) — passes
- `npx eslint src/pages/Compression/components/ReviewScreen.tsx --max-warnings=0` — passes