### PR TITLE
Fix HumanSeconds mangling fractional-second input

### DIFF
--- a/src/utils/Functions.js
+++ b/src/utils/Functions.js
@@ -7,6 +7,7 @@ export function HumanSeconds(seconds) {
   if (seconds === 0) {
     return '0s'
   }
+  seconds = Math.floor(seconds)
   const numyears = Math.floor(seconds / 31536000)
   const numdays = Math.floor((seconds % 31536000) / 86400)
   const numhours = Math.floor(((seconds % 31536000) % 86400) / 3600)

--- a/src/utils/Functions.test.js
+++ b/src/utils/Functions.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+
+import { HumanSeconds, HumanSize } from './Functions'
+
+describe('HumanSeconds', () => {
+  it('formats zero', () => {
+    expect(HumanSeconds(0)).toBe('0s')
+  })
+
+  it('formats seconds only', () => {
+    expect(HumanSeconds(5)).toBe('05s')
+  })
+
+  it('pads minutes and seconds', () => {
+    expect(HumanSeconds(65)).toBe('01m 05s')
+  })
+
+  it('rolls minutes over into hours at the 60m boundary', () => {
+    expect(HumanSeconds(3599)).toBe('59m 59s')
+    expect(HumanSeconds(3600)).toBe('01h ')
+  })
+
+  it('rolls hours over into days at the 24h boundary', () => {
+    expect(HumanSeconds(86399)).toBe('23h 59m 59s')
+    expect(HumanSeconds(86400)).toBe('1d ')
+  })
+
+  it('floors fractional seconds instead of corrupting the padded output', () => {
+    expect(HumanSeconds(65.5)).toBe('01m 05s')
+    expect(HumanSeconds(5.5)).toBe('05s')
+  })
+})
+
+describe('HumanSize', () => {
+  it('formats bytes below the threshold as-is', () => {
+    expect(HumanSize(500)).toBe('500 B')
+  })
+
+  it('formats binary units by default', () => {
+    expect(HumanSize(1024)).toBe('1.0 KiB')
+  })
+
+  it('formats SI units when requested', () => {
+    expect(HumanSize(1000, true)).toBe('1.0 kB')
+  })
+
+  it('respects the decimal places argument', () => {
+    expect(HumanSize(1536, false, 2)).toBe('1.50 KiB')
+  })
+})


### PR DESCRIPTION
## What changed

`HumanSeconds` in `src/utils/Functions.js` computed four of its five
time components (years/days/hours/minutes) with `Math.floor`, but left
`numseconds` un-floored. When called with a fractional value, `pad()`
(`` `0${n}`.slice(-2) ``) sliced the last two characters of the decimal
string instead of zero-padding a number, silently corrupting the output
(e.g. `HumanSeconds(65.5)` produced `"01m .5s"` instead of `"1m 05s"`).

Fixed by flooring the input once at the top of the function.

Also adds `src/utils/Functions.test.js`, since this module previously
had no test coverage at all despite being a shared, exported util.
Covers `HumanSeconds` boundary cases (minute/hour/day rollovers) and
the fractional-seconds case that previously broke, plus basic
`HumanSize` coverage.

## Why

`HumanSeconds`'s only current caller (`node.uptime` in
`src/pages/Status/Status.tsx`) happens to always pass whole seconds
from Centrifugo, so this wasn't user-visible today. But it's a real
defect in the function's own contract, and it's exported from a shared
utils module other callers could reasonably feed a computed
(potentially fractional) duration into.

## How verified

- `npx tsc --noEmit` — passes
- `npx vitest run` — all 4 test files / 13 tests pass
- `npx eslint src --max-warnings=0` — passes