### PR TITLE
Fix analytics dashboard auto-refresh dying after first fetch

### DIFF
--- a/src/pages/Analytics/Analytics.tsx
+++ b/src/pages/Analytics/Analytics.tsx
@@ -668,19 +668,13 @@ const DashboardTab = ({ signinSilent, authorization }: AnalyticsProps) => {
     [signinSilent, showAlert, request, rawRequest]
   )
 
-  const [didFetch, setDidFetch] = useState(false)
-
   useEffect(() => {
-    if (didFetch) {
-      return
-    }
-    setDidFetch(true)
     const interval = setInterval(function () {
       askFullAnalyticsData()
     }, 60000)
     askFullAnalyticsData()
     return () => clearInterval(interval)
-  }, [askFullAnalyticsData, signinSilent, authorization, showAlert, didFetch])
+  }, [askFullAnalyticsData, signinSilent, authorization, showAlert])
 
   const widgetCellSx = { p: 1.5 }
   // Distribution chips (SDKs / transports / push platforms) flow in a wrapping row.


### PR DESCRIPTION
## What

The Analytics dashboard's periodic-refresh effect (`DashboardTab` in `src/pages/Analytics/Analytics.tsx`) used a `didFetch` state flag both set inside the effect and listed in that same effect's dependency array:

```js
const [didFetch, setDidFetch] = useState(false)
useEffect(() => {
  if (didFetch) return
  setDidFetch(true)
  const interval = setInterval(() => askFullAnalyticsData(), 60000)
  askFullAnalyticsData()
  return () => clearInterval(interval)
}, [askFullAnalyticsData, signinSilent, authorization, showAlert, didFetch])
```

## Why it's a bug

On mount, the effect runs, calls `setDidFetch(true)`, and creates the interval. Because `didFetch` changed and is in the deps array, React re-runs the effect right after: the cleanup fires first (clearing the interval that was just created), then the new run sees `didFetch === true` and returns immediately without creating a new interval. Net result: `askFullAnalyticsData()` runs exactly once on mount and never again — the dashboard silently stops refreshing, despite the apparent 60s auto-refresh intent.

## Fix

Removed the `didFetch` guard entirely. The effect now matches the plain interval-effect pattern already used elsewhere in this codebase (e.g. `src/pages/Status/Status.tsx`), which has no such guard and refreshes correctly.

## How I verified

- Wrote a temporary, throwaway test (not included in this diff) using `renderHook` + `vitest` fake timers that reproduced the exact effect shape in isolation:
  - The buggy pattern (state flag set inside the effect, included in its own deps) fetched exactly once even after advancing fake timers by 3 intervals.
  - The fixed pattern (no such flag) fetched on every tick as expected.
  - This confirmed the root-cause mechanism (React re-running the effect synchronously after the self-triggered state update) before touching the real file.
- I didn't keep this test in the tree: it exercised a reimplementation of the effect shape, not the actual `Analytics.tsx` component, and a real regression test would need heavy mocking (fetch, `ShellContext`, router params, MUI dialogs) that isn't already set up for this component elsewhere in the suite — disproportionate to this one-line fix.
- Ran `tsc --noEmit` (passes), `npm test` (13/13 passing), and `npm run lint` (clean) against the actual change.