### PR TITLE
Surface device_list errors on the Push Notifications page

### DIFF
--- a/src/pages/PushNotification/PushNotification.test.tsx
+++ b/src/pages/PushNotification/PushNotification.test.tsx
@@ -1,0 +1,59 @@
+import { render, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { vi, describe, test, expect } from 'vitest'
+
+import { ShellContext } from 'contexts/ShellContext'
+
+import { PushNotification } from './PushNotification'
+
+// device_list failures used to be swallowed silently: the fetch effect
+// checked `data.error` and just returned, with no alert and no call to
+// handleError, unlike every other API call in this file (e.g.
+// send_push_notification) which surfaces `data.error` via showAlert. An
+// operator hitting a permission or backend error here saw nothing at all.
+describe('PushNotification', () => {
+  test('shows an alert when device_list returns an error', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ error: { message: 'permission denied' } }),
+      })
+    )
+    // Node's own experimental global `localStorage` shadows jsdom's window.localStorage
+    // in this environment; stub it so the component's synchronous localStorage.getItem
+    // read on mount doesn't throw.
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {},
+    })
+
+    const showAlert = vi.fn()
+
+    render(
+      <MemoryRouter>
+        <ShellContext.Provider
+          value={{
+            numberOfPeers: 1,
+            tabHasFocus: true,
+            setNumberOfPeers: () => {},
+            setTitle: () => {},
+            showAlert,
+          }}
+        >
+          <PushNotification
+            signinSilent={() => {}}
+            authorization=""
+            edition="oss"
+          />
+        </ShellContext.Provider>
+      </MemoryRouter>
+    )
+
+    await waitFor(() =>
+      expect(showAlert).toHaveBeenCalledWith('Error: permission denied', {
+        severity: 'error',
+      })
+    )
+  })
+})

--- a/src/pages/PushNotification/PushNotification.tsx
+++ b/src/pages/PushNotification/PushNotification.tsx
@@ -377,6 +377,7 @@ export function PushNotification({
           return
         }
         if (data.error) {
+          showAlert('Error: ' + data.error.message, { severity: 'error' })
           return
         }
         setEnabled(true)
@@ -399,6 +400,7 @@ export function PushNotification({
     command,
     handleError,
     getDeviceFilter,
+    showAlert,
   ])
 
   // Constrain long identifier columns: truncate with an ellipsis (full value in


### PR DESCRIPTION
## What changed

In `PushNotification.tsx`, the `device_list` fetch (used to populate the devices table) checked `data.error` and silently returned when the API call failed — no alert, no call to `handleError`. Every other command in this file (e.g. `send_push_notification`) surfaces a `data.error` response via `showAlert('Error: ' + data.error.message, { severity: 'error' })`. An operator hitting a permission or backend error while loading/paginating/filtering devices saw no feedback at all — just a stale or empty table with no indication anything went wrong.

Fix: apply the same `showAlert` pattern already used elsewhere in this file. Also added `showAlert` to the effect's dependency array, since it's now referenced inside.

## Why

Silent failures on an admin page are confusing for operators — they can't tell whether there are genuinely zero devices or the request failed.

## How verified

- Added `src/pages/PushNotification/PushNotification.test.tsx`, which mocks `fetch` to return `{ error: { message: 'permission denied' } }` for `device_list` and asserts `showAlert` is called with `'Error: permission denied'`.
- Confirmed the test fails against the pre-fix code (stashed the fix, reran — test failed because `showAlert` was never called) and passes with the fix applied.
- `tsc --noEmit`, `eslint src --max-warnings=0`, and the full `vitest run` suite (5 files, 14 tests) all pass.