### PR TITLE
Fix SnapshotDetail showing stale data after navigating to a new snapshot

### DIFF
--- a/src/pages/Snapshots/components/SnapshotDetail.test.tsx
+++ b/src/pages/Snapshots/components/SnapshotDetail.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { vi, describe, test, expect } from 'vitest'
+
+import { SnapshotDetail } from './SnapshotDetail'
+
+// SnapshotDetail seeded its `snapshot` state from the `snapshot` prop via
+// useState(initialSnapshot) with no effect to resync it. Navigating from one
+// snapshot's detail page straight to another's (e.g. creating a connections
+// snapshot from a channel row, which navigates to /snapshots/<new-id> without
+// unmounting this component) left the view — and the polling loop's
+// snapshot_id — stuck on the previous snapshot.
+describe('SnapshotDetail', () => {
+  test('updates when navigated to a different snapshot without remounting', () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) })
+    )
+
+    const completed = {
+      snapshot_id: 'snap-a',
+      kind: 'channels',
+      status: 'completed',
+      filter: { channels: { pattern: '*' } },
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      rows_inserted: 10,
+      nodes_expected: 3,
+      nodes_reported: 3,
+      requested_by: 'alice',
+    }
+    const running = {
+      ...completed,
+      snapshot_id: 'snap-b',
+      kind: 'connections',
+      status: 'running',
+      filter: { connections: {} },
+      requested_by: 'bob',
+    }
+
+    const { rerender } = render(
+      <MemoryRouter>
+        <SnapshotDetail
+          snapshot={completed}
+          authorization=""
+          signinSilent={() => {}}
+        />
+      </MemoryRouter>
+    )
+    expect(screen.getByText('Completed')).toBeInTheDocument()
+
+    rerender(
+      <MemoryRouter>
+        <SnapshotDetail
+          snapshot={running}
+          authorization=""
+          signinSilent={() => {}}
+        />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByText('Running')).toBeInTheDocument()
+    expect(screen.queryByText('Completed')).not.toBeInTheDocument()
+  })
+})

--- a/src/pages/Snapshots/components/SnapshotDetail.tsx
+++ b/src/pages/Snapshots/components/SnapshotDetail.tsx
@@ -122,6 +122,13 @@ export const SnapshotDetail = ({
   const navigate = useNavigate()
   const { rawRequest } = useAdminApi({ authorization, signinSilent })
 
+  // Resync when navigated straight from one snapshot's detail page to
+  // another's (e.g. creating a connections snapshot from a channel row),
+  // which changes the `snapshot` prop without unmounting this component.
+  useEffect(() => {
+    setSnapshot(initialSnapshot)
+  }, [initialSnapshot])
+
   const fetchSnapshotUpdate = useCallback(async () => {
     try {
       const response = await rawRequest(


### PR DESCRIPTION
## What changed

`SnapshotDetail` seeded its local `snapshot` state from the `snapshot` prop via `useState(initialSnapshot)` with no effect to resync it when the prop changes later.

`Snapshots.tsx` never remounts `SnapshotDetail` when the route `id` param changes (no `key` prop on it), so any navigation from one snapshot's detail page straight to another's without an intervening unmount leaves the component showing the *old* snapshot's data — including its `status` and `snapshot_id` — even though the parent has already fetched and passed down the new snapshot.

## Why it matters

This is reachable from the UI: on a completed "channels" snapshot's detail page, each row in `ChannelsTable` has a "create connections snapshot" action for that channel. Submitting it calls `navigate(/snapshots/<new-id>)`, which only changes the route param — `SnapshotDetail` stays mounted. The result: the page keeps rendering the previous snapshot's status/table (e.g. still "Completed" instead of "Running"), and the polling effect keeps refreshing using the *previous* `snapshot_id`, so the new snapshot's progress is never picked up.

Fix: add a `useEffect` that resyncs local state whenever the `snapshot` prop changes.

## Test plan

Added `SnapshotDetail.test.tsx`: renders `SnapshotDetail` with a completed snapshot A, then rerenders (same component instance, matching how `Snapshots.tsx` actually re-renders it) with a running snapshot B. Asserts the "Running" status is now shown and "Completed" is gone.

- Confirmed the test fails against the old code (stuck showing "Completed" and rendering the wrong table for `kind`).
- Confirmed it passes with the fix.
- Kept the test in the tree: it guards a real stale-derived-state class of bug distinct from ones already fixed in this repo, isn't redundant with existing coverage, and isn't tied to fragile internals.

Verified with `tsc --noEmit`, `eslint src --max-warnings=0`, and the full `vitest run` suite (6 files / 15 tests, all passing).