### PR TITLE
Fix stale-data race in Analytics User/Channel explorers

### DIFF
--- a/src/pages/Analytics/ChannelExplorer.test.tsx
+++ b/src/pages/Analytics/ChannelExplorer.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { vi, describe, test, expect } from 'vitest'
+
+import { ChannelExplorer } from './ChannelExplorer'
+
+// TrendPanel pulls in the echarts bundle via a dynamic import, which isn't relevant
+// to this test and doesn't render usefully under jsdom's canvas-less environment.
+vi.mock('./TrendPanel', () => ({ TrendPanel: () => null }))
+
+const channelData = (channel: string, subscribers: number) => ({
+  result: {
+    channel,
+    found: true,
+    namespace: '',
+    summary: {
+      subscribers,
+      publications: 0,
+      publishers: 0,
+      bytes: 0,
+      errors: 0,
+    },
+    topPublishers: [],
+    topSubscribers: [],
+    events: [],
+  },
+})
+
+// Same cancellation-guard bug as UserExplorer: an in-flight request for a
+// previously-committed channel could resolve after a newer request and
+// overwrite the screen with stale data for the wrong channel.
+describe('ChannelExplorer', () => {
+  test('a slow, stale response does not overwrite a newer lookup', async () => {
+    let resolveOld: (v: unknown) => void = () => {}
+    const oldPromise = new Promise(resolve => {
+      resolveOld = resolve
+    })
+
+    // Node's own experimental global `localStorage` shadows jsdom's window.localStorage
+    // in this environment; stub it so the component's synchronous localStorage reads/writes
+    // don't throw.
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {},
+    })
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((_url: string, init?: RequestInit) => {
+        const body = JSON.parse((init?.body as string) || '{}')
+        if (body.channel === 'chan-a') {
+          return oldPromise.then(() => ({
+            ok: true,
+            json: async () => channelData('chan-a', 111),
+          }))
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => channelData('chan-b', 222),
+        })
+      })
+    )
+
+    render(
+      <MemoryRouter>
+        <ChannelExplorer authorization="" signinSilent={() => {}} />
+      </MemoryRouter>
+    )
+
+    const input = screen.getByLabelText('Channel')
+
+    fireEvent.change(input, { target: { value: 'chan-a' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    fireEvent.change(input, { target: { value: 'chan-b' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => expect(screen.getByText('222')).toBeInTheDocument())
+
+    await act(async () => {
+      resolveOld(undefined)
+      // Flush the chained .then() hops (response -> json -> setData) plus
+      // React's state-update microtask.
+      for (let i = 0; i < 5; i++) await Promise.resolve()
+    })
+
+    expect(screen.getByText('222')).toBeInTheDocument()
+    expect(screen.queryByText('111')).not.toBeInTheDocument()
+  })
+})

--- a/src/pages/Analytics/ChannelExplorer.tsx
+++ b/src/pages/Analytics/ChannelExplorer.tsx
@@ -176,6 +176,7 @@ export const ChannelExplorer = ({
       setData(null)
       return
     }
+    let cancelled = false
     setLoading(true)
     const now = Math.floor(Date.now() / 1000)
     rawRequest(`admin/analytics/channel`, {
@@ -188,15 +189,20 @@ export const ChannelExplorer = ({
           if (handleHttpError(r.status)) return null
           throw Error(r.status.toString())
         }
-        setEnabled(true)
+        if (!cancelled) setEnabled(true)
         return r.json()
       })
       .then(p => {
-        if (!p) return
+        if (!p || cancelled) return
         setData(p.result)
         setLoading(false)
       })
-      .catch(() => setLoading(false))
+      .catch(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
   }, [channel, rangeSeconds, rawRequest, handleHttpError])
 
   useEffect(() => {

--- a/src/pages/Analytics/UserExplorer.test.tsx
+++ b/src/pages/Analytics/UserExplorer.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { vi, describe, test, expect } from 'vitest'
+
+import { UserExplorer } from './UserExplorer'
+
+// TrendPanel pulls in the echarts bundle via a dynamic import, which isn't relevant
+// to this test and doesn't render usefully under jsdom's canvas-less environment.
+vi.mock('./TrendPanel', () => ({ TrendPanel: () => null }))
+
+const userProfile = (name: string, connections: number) => ({
+  result: {
+    user: name,
+    found: true,
+    profile: {
+      name,
+      version: '',
+      transport: '',
+      labels: {},
+      firstSeen: 0,
+      lastSeen: 0,
+    },
+    summary: {
+      connections,
+      operations: 0,
+      errors: 0,
+      disconnects: 0,
+      publications: 0,
+      channels: 0,
+      latencyP95: 0,
+      connLatencyP95: 0,
+    },
+    channels: [],
+    events: [],
+  },
+})
+
+// The fetch effect had no cancellation guard, so an in-flight request for a
+// previously-committed user could resolve after a newer request and overwrite
+// the screen with stale data for the wrong user (e.g. looking up "alice",
+// then quickly looking up "bob" before alice's slower response lands).
+describe('UserExplorer', () => {
+  test('a slow, stale response does not overwrite a newer lookup', async () => {
+    let resolveAlice: (v: unknown) => void = () => {}
+    const alicePromise = new Promise(resolve => {
+      resolveAlice = resolve
+    })
+
+    // Node's own experimental global `localStorage` shadows jsdom's window.localStorage
+    // in this environment; stub it so the component's synchronous localStorage reads/writes
+    // don't throw.
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {},
+    })
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((_url: string, init?: RequestInit) => {
+        const body = JSON.parse((init?.body as string) || '{}')
+        if (body.user === 'alice') {
+          return alicePromise.then(() => ({
+            ok: true,
+            json: async () => userProfile('alice', 111),
+          }))
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => userProfile('bob', 222),
+        })
+      })
+    )
+
+    render(
+      <MemoryRouter>
+        <UserExplorer authorization="" signinSilent={() => {}} />
+      </MemoryRouter>
+    )
+
+    const input = screen.getByLabelText('User ID')
+
+    fireEvent.change(input, { target: { value: 'alice' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    fireEvent.change(input, { target: { value: 'bob' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => expect(screen.getByText('222')).toBeInTheDocument())
+
+    await act(async () => {
+      resolveAlice(undefined)
+      // Flush the chained .then() hops (response -> json -> setData) plus
+      // React's state-update microtask.
+      for (let i = 0; i < 5; i++) await Promise.resolve()
+    })
+
+    expect(screen.getByText('222')).toBeInTheDocument()
+    expect(screen.queryByText('111')).not.toBeInTheDocument()
+  })
+})

--- a/src/pages/Analytics/UserExplorer.tsx
+++ b/src/pages/Analytics/UserExplorer.tsx
@@ -150,6 +150,7 @@ export const UserExplorer = ({
       setData(null)
       return
     }
+    let cancelled = false
     setLoading(true)
     const now = Math.floor(Date.now() / 1000)
     rawRequest('admin/analytics/user', {
@@ -162,17 +163,20 @@ export const UserExplorer = ({
           if (handleHttpError(r.status)) return null
           throw Error(r.status.toString())
         }
-        setEnabled(true)
+        if (!cancelled) setEnabled(true)
         return r.json()
       })
       .then(p => {
-        if (!p) return
+        if (!p || cancelled) return
         setData(p.result)
         setLoading(false)
       })
       .catch(() => {
-        setLoading(false)
+        if (!cancelled) setLoading(false)
       })
+    return () => {
+      cancelled = true
+    }
   }, [user, rangeSeconds, rawRequest, handleHttpError])
 
   // Persist user + range to URL (shareable) and localStorage (last user).


### PR DESCRIPTION
## What changed

`UserExplorer` and `ChannelExplorer` (Analytics pages) each fetch profile/summary
data in a `useEffect` keyed on the committed user/channel, but had no
cancellation guard on the in-flight request. Every comparable fetch effect
elsewhere in this codebase (`useChannelResolution`, `TrendPanel`, etc.) guards
its `setState` calls with a `cancelled` flag set in the effect cleanup — these
two were the outliers.

## Why

Concretely: look up one user (e.g. "alice", slow request in flight), then look
up another ("bob") before alice's response lands. The slower, stale response
can resolve after the newer one and silently overwrite the screen with data
for the no-longer-displayed identity — no error, no visual indication, just
wrong data attributed to whoever is currently shown. Same failure mode for
`ChannelExplorer` and for switching the time-range mid-fetch.

The fix adds a `cancelled` flag set in each effect's cleanup, matching the
pattern already used elsewhere, so a superseded request's response is
ignored.

## How verified

Added `UserExplorer.test.tsx` and `ChannelExplorer.test.tsx`, each simulating
the race: commit "alice"/"chan-a" (response held pending), then commit
"bob"/"chan-b" (response resolves immediately), then let the first response
resolve late. Asserts the screen still shows the second (correct) data, not
the stale first response.

Verified both tests fail against the pre-fix code (screen reverts to the
stale response after the late resolve) and pass with the fix, so they
genuinely exercise the race rather than just checking final state.

Also ran the full suite (`npm run lint`, `tsc --noEmit`, `npm test`, `npm run
build`) — all green.