### PR TITLE
Match Centrifugo channel resolution for private channels in Inspector

### DIFF
--- a/src/pages/Inspector/channel/CapabilityHeader.tsx
+++ b/src/pages/Inspector/channel/CapabilityHeader.tsx
@@ -7,6 +7,7 @@ import { alpha, useTheme } from '@mui/material/styles'
 import {
   ChannelOptions,
   ResolvedChannel,
+  channelRest,
   subscriptionType,
   hasPresence,
   hasHistory,
@@ -31,9 +32,10 @@ const regexMatch = (
 ): boolean | null => {
   const re = resolved.options.channel_regex
   if (!re) return null
-  const rest = resolved.namespace
-    ? resolved.channel.slice(resolved.namespace.length + boundary.length)
-    : resolved.channel
+  // The namespace name isn't necessarily the literal channel prefix (a private
+  // channel is `$news:index` but resolves to `news`), so cut at the boundary
+  // rather than by the namespace name's length.
+  const rest = channelRest(resolved.channel, boundary)
   try {
     return new RegExp(re).test(rest)
   } catch {

--- a/src/pages/Inspector/channelOptions.test.ts
+++ b/src/pages/Inspector/channelOptions.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+
+import { channelRest, resolveChannel } from './channelOptions'
+
+const cfg = {
+  channel: {
+    namespace_boundary: ':',
+    private_prefix: '$',
+    without_namespace: { presence: true },
+    namespaces: [{ name: 'news', history_size: 10 }],
+  },
+}
+
+describe('resolveChannel', () => {
+  it('resolves a channel without a namespace to without_namespace options', () => {
+    expect(resolveChannel('index', cfg)).toEqual({
+      channel: 'index',
+      namespace: null,
+      known: true,
+      options: { presence: true },
+    })
+  })
+
+  it('resolves a namespaced channel to that namespace', () => {
+    const r = resolveChannel('news:index', cfg)
+    expect(r.namespace).toBe('news')
+    expect(r.known).toBe(true)
+    expect(r.options.history_size).toBe(10)
+  })
+
+  it('marks a channel in an unconfigured namespace as unknown', () => {
+    expect(resolveChannel('nope:index', cfg)).toEqual({
+      channel: 'nope:index',
+      namespace: 'nope',
+      known: false,
+      options: {},
+    })
+  })
+
+  it('strips the private prefix before finding the namespace', () => {
+    const r = resolveChannel('$news:index', cfg)
+    expect(r.namespace).toBe('news')
+    expect(r.known).toBe(true)
+    expect(r.options.history_size).toBe(10)
+  })
+
+  it('treats an empty namespace part as without_namespace', () => {
+    const r = resolveChannel(':index', cfg)
+    expect(r.namespace).toBeNull()
+    expect(r.known).toBe(true)
+    expect(r.options).toEqual({ presence: true })
+  })
+
+  it('does not strip a private prefix the server does not use', () => {
+    const noPrefix = {
+      channel: { ...cfg.channel, private_prefix: '' },
+    }
+    const r = resolveChannel('$news:index', noPrefix)
+    expect(r.namespace).toBe('$news')
+    expect(r.known).toBe(false)
+  })
+
+  it('does not split at all when the boundary is disabled', () => {
+    const noBoundary = {
+      channel: { ...cfg.channel, namespace_boundary: '' },
+    }
+    const r = resolveChannel('news:index', noBoundary)
+    expect(r.namespace).toBeNull()
+    expect(r.options).toEqual({ presence: true })
+  })
+
+  it('falls back to server defaults when the config omits the fields', () => {
+    const r = resolveChannel('$news:index', {
+      channel: { namespaces: [{ name: 'news', history_size: 10 }] },
+    })
+    expect(r.namespace).toBe('news')
+    expect(r.known).toBe(true)
+  })
+})
+
+describe('channelRest', () => {
+  it('returns the whole channel when there is no boundary in it', () => {
+    expect(channelRest('index', ':')).toBe('index')
+  })
+
+  it('returns the part after the first boundary', () => {
+    expect(channelRest('news:index:2', ':')).toBe('index:2')
+  })
+
+  it('keeps the private prefix out of the rest', () => {
+    expect(channelRest('$news:index', ':')).toBe('index')
+  })
+
+  it('returns the whole channel when the boundary is disabled', () => {
+    expect(channelRest('news:index', '')).toBe('news:index')
+  })
+})

--- a/src/pages/Inspector/channelOptions.ts
+++ b/src/pages/Inspector/channelOptions.ts
@@ -2,9 +2,10 @@
 //
 // The admin config endpoint returns an *annotated node tree*; `reconstructConfig`
 // turns it back into a plain object, and `resolveChannel` mirrors Centrifugo's own
-// resolution (see internal/config/container.go `ChannelOptions`): split the channel
-// on the namespace boundary, match the prefix against a configured namespace, and
-// fall back to `channel.without_namespace` when there is no prefix.
+// resolution (see internal/config/container.go `ChannelOptions`): strip the private
+// prefix, split the channel on the namespace boundary, match the prefix against a
+// configured namespace, and fall back to `channel.without_namespace` when the
+// channel carries no namespace prefix.
 //
 // Keeping this pure and typed makes the Channel inspector's rendering a simple
 // function of the resolved options — easy to extend as Centrifugo grows new options.
@@ -133,23 +134,48 @@ export function reconstructConfig(
 
 // ---- resolution ------------------------------------------------------------
 
+// Read a string config field, falling back to the server's own default when the
+// field is absent (older server, or a config endpoint that doesn't expose it). An
+// explicitly empty value is kept: an empty boundary disables namespaces, and an
+// empty private prefix disables the private-channel marker.
+const strOption = (v: unknown, fallback: string): string =>
+  typeof v === 'string' ? v : fallback
+
+// The part of the channel a namespace's `channel_regex` is matched against —
+// everything after the first namespace boundary, or the whole channel when there
+// is none. Mirrors the `rest` the server derives in Container.ChannelOptions; the
+// private prefix sits before the boundary, so it never leaks into the rest.
+export const channelRest = (channel: string, boundary: string): string => {
+  const at = boundary ? channel.indexOf(boundary) : -1
+  return at === -1 ? channel : channel.slice(at + boundary.length)
+}
+
 export function resolveChannel(
   channel: string,
   cfg: Record<string, any>
 ): ResolvedChannel {
   const chCfg = (cfg?.channel ?? {}) as Record<string, any>
-  const boundary: string = chCfg.namespace_boundary || ':'
+  const boundary = strOption(chCfg.namespace_boundary, ':')
+  const privatePrefix = strOption(chCfg.private_prefix, '$')
   const namespaces: Array<Record<string, any>> = Array.isArray(chCfg.namespaces)
     ? chCfg.namespaces
     : []
   const withoutNs: ChannelOptions = (chCfg.without_namespace ??
     {}) as ChannelOptions
 
-  const idx = channel.indexOf(boundary)
-  if (idx === -1) {
+  // The server strips the private prefix before looking for the boundary, so
+  // `$news:index` lives in the `news` namespace like `news:index` does.
+  const trimmed =
+    privatePrefix && channel.startsWith(privatePrefix)
+      ? channel.slice(privatePrefix.length)
+      : channel
+  const idx = boundary ? trimmed.indexOf(boundary) : -1
+  // No boundary, or an empty namespace part (`:index`), means without_namespace —
+  // the server looks options up by namespace name, and "" is the default one.
+  const nsName = idx === -1 ? '' : trimmed.slice(0, idx)
+  if (!nsName) {
     return { channel, namespace: null, known: true, options: withoutNs }
   }
-  const nsName = channel.slice(0, idx)
   const ns = namespaces.find(n => n?.name === nsName)
   if (!ns) {
     return { channel, namespace: nsName, known: false, options: {} }


### PR DESCRIPTION
## What

Makes the Inspector's channel resolution agree with Centrifugo's own (`internal/config/container.go`, `Container.namespaceName` / `channelOpts`).

**1. `resolveChannel` ignored `channel.private_prefix`.**
It split the raw channel name on the namespace boundary. Centrifugo trims the private prefix (default `$`) *first*, so `$news:index` resolves to the `news` namespace server-side, but here it resolved to a namespace literally named `$news`. That namespace is never configured, so the Channel tab rendered the warning "No namespace `$news` is configured — Centrifugo would reject subscriptions to this channel" and hid every live panel (presence, history, map) plus the proxy summary for a channel that is perfectly valid. This is the fallback resolver used when the PRO `admin/api/channel_options` endpoint is unavailable (older servers).

Two smaller mismatches in the same function:
- a channel whose namespace part is empty (`:index`) is `without_namespace` on the server — `channelOpts` looks options up by name and `""` is the default namespace — but was reported as an unknown namespace here;
- an explicitly empty `namespace_boundary` disables namespace splitting on the server, while `chCfg.namespace_boundary || ':'` silently fell back to `:`. Absent fields still fall back to the server defaults (`:` and `$`), which is what the old code was reaching for.

**2. `CapabilityHeader` had the same blind spot on the primary path.**
It derived the `channel_regex` subject by slicing off `namespace.length + boundary.length`, which assumes the namespace name is the literal channel prefix. For `$news:index` the server endpoint returns namespace `news`, so it tested the regex against `ews:index` and could show "name does NOT match — would be rejected" for a channel the server accepts. Replaced with a small exported `channelRest(channel, boundary)` that cuts at the boundary, mirroring the `rest` the server matches `channel_regex` against (`Handler.validChannelName`).

No API or behavior change for channels without a private prefix.

## Verifying test

Added `src/pages/Inspector/channelOptions.test.ts` — the file had no tests. It covers `resolveChannel` (plain, namespaced, unknown-namespace, private-prefixed, empty namespace part, empty private prefix, disabled boundary, config omitting the fields) and `channelRest`.

Against the old code 4 of the `resolveChannel` cases failed:

```
× strips the private prefix before finding the namespace
    expected '$news' to be 'news'
× treats an empty namespace part as without_namespace
    expected '' to be null
× does not split at all when the boundary is disabled
    expected 'news' to be null
× falls back to server defaults when the config omits the fields
    expected '$news' to be 'news'
```

They pass with the fix. Keeping the tests: `resolveChannel` is pure, is the piece most likely to drift from the server's rules as Centrifugo grows options, and the assertions are on its documented contract rather than internals.

## How verified

- `npx vitest run` — 9 files, 29 tests passing (was 8 / 17).
- `npx tsc --noEmit` — clean.
- `npx eslint src --max-warnings=0` — clean.
- `npx vite build` — succeeds (`dist/` intentionally left at its committed state).